### PR TITLE
Draw canvas internally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/paper-wallet",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1791,6 +1791,11 @@
         "nan": "^2.12.1",
         "node-pre-gyp": "^0.11.0"
       }
+    },
+    "canvas-text-wrapper": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/canvas-text-wrapper/-/canvas-text-wrapper-0.10.2.tgz",
+      "integrity": "sha512-nFnN8q8ydtkBUWVn/dAdetpwNOkz3KtyD6jTI2HGD43ant2FQcnLugAVaGLJloyRTNK/exn7efpYy2zPV5bHiQ=="
     },
     "chai": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@discipl/core": "^0.11.1",
     "canvas": "^2.4.1",
+    "canvas-text-wrapper": "^0.10.2",
     "json-stable-stringify": "^1.0.1",
     "jsqr": "^1.2.0",
     "pako": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/paper-wallet",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "library for creating paper wallets consisting of a QR holding an attested claim as a verifiable credential",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,8 @@ let template = {
   qrOffsetXright: 550,
   qrOffsetYbottom: 700,
   qrSizeMin: 150,
-  footerFont: "10px helvetica",
-  footerText: "Dit is een automatisch gegenereerd document en daarom niet ondertekend. De gegevens zijn verkregen via NLX en geborgd in de QR-code. U kunt de echtheid van dit document controleren via een bijbehorende app of online",
+  footerFont: '10px helvetica',
+  footerText: 'Dit is een automatisch gegenereerd document en daarom niet ondertekend. De gegevens zijn verkregen via NLX en geborgd in de QR-code. U kunt de echtheid van dit document controleren via een bijbehorende app of online',
   footerWidth: 400,
   footerHeight: 200,
   footerOffsetX: 90,
@@ -75,10 +75,10 @@ const toCanvas = async (vc, template, canvas) => {
   ctx.fillText(template.subheaderText, template.subheaderOffsetX, template.subheaderOffsetY)
 
   // draw a line
-  ctx.beginPath();
-  ctx.moveTo(40, 250);
-  ctx.lineTo(570, 250);
-  ctx.stroke();
+  ctx.beginPath()
+  ctx.moveTo(40, 250)
+  ctx.lineTo(570, 250)
+  ctx.stroke()
 
   ctx.font = template.claimDataFont
   let line = 0
@@ -93,15 +93,15 @@ const toCanvas = async (vc, template, canvas) => {
     }
   }
   let qrImage = await loadImage(vc.qr)
-  let QRSize = Math.max((42+(8*vc.version))*595/(21*25), template.qrSizeMin)
-  ctx.drawImage(qrImage, template.qrOffsetXright-QRSize, template.qrOffsetYbottom-QRSize, QRSize, QRSize)
+  let QRSize = Math.max((42 + (8 * vc.version)) * 595 / (21 * 25), template.qrSizeMin)
+  ctx.drawImage(qrImage, template.qrOffsetXright - QRSize, template.qrOffsetYbottom - QRSize, QRSize, QRSize)
   // draw footer
   CanvasTextWrapper(canvas, template.footerText, {
-        font: template.footerFont,
-        paddingX: template.footerOffsetX,
-        paddingY: template.footerOffsetY,
-        textAlign: "center"
-      });
+    font: template.footerFont,
+    paddingX: template.footerOffsetX,
+    paddingY: template.footerOffsetY,
+    textAlign: 'center'
+  })
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import jsQR from 'jsqr'
 import * as core from '@discipl/core'
 import stringify from 'json-stable-stringify'
 import { loadImage } from 'canvas'
-var CanvasTextWrapper = require('canvas-text-wrapper').CanvasTextWrapper;
+import { CanvasTextWrapper } from 'canvas-text-wrapper'
 
 /**
  * a default template
@@ -12,6 +12,7 @@ var CanvasTextWrapper = require('canvas-text-wrapper').CanvasTextWrapper;
 let template = {
   backgroundImage: 'images/template.png',
   logoImage: 'images/logo.png',
+  disciplImage: 'discipl.svg',
   logoWidth: 150,
   logoHeight: 150,
   canvasWidth: 595, // 8.27 inch @ 72 dpi
@@ -24,10 +25,15 @@ let template = {
   claimDataOffsetX: 25,
   claimDataOffsetY: 200,
   claimDataLineSpacing: 10,
-  qrOffsetX: 225,
-  qrOffsetY: 200,
-  qrWidth: 350,
-  qrHeight: 350
+  qrOffsetXright: 550,
+  qrOffsetYbottom: 700,
+  qrSizeMin: 150,
+  footerFont: "10px helvetica",
+  footerText: "Dit is een automatisch gegenereerd document en daarom niet ondertekend. De gegevens zijn verkregen via NLX en geborgd in de QR-code. U kunt de echtheid van dit document controleren via een bijbehorende app of online",
+  footerWidth: 400,
+  footerHeight: 200,
+  footerOffsetX: 90,
+  footerOffsetY: 730
 }
 
 /**
@@ -45,7 +51,8 @@ const issue = async (claimLink, ssid) => {
   let claimData = await core.exportLD(claimLink, ssid)
   let data = stringify(claimData)
   let qr = await QRCode.toDataURL(data)
-  return { claimData: claimData, qr: qr }
+  let ver = (await QRCode.create(data)).version
+  return { claimData: claimData, qr: qr, version: ver }
 }
 
 /**
@@ -60,7 +67,6 @@ const toCanvas = async (vc, template, canvas) => {
   ctx.drawImage(await loadImage(template.backgroundImage), 0, 0, canvas.width, canvas.height)
   ctx.drawImage(await loadImage(template.logoImage), 0, 0, template.logoWidth, template.logoHeight)
   ctx.drawImage(await loadImage(template.disciplImage), template.disciplOffsetX, template.disciplOffsetY, template.disciplWidth, template.disciplHeight)
-
   ctx.font = template.productHeaderFont
   ctx.fillText(template.productHeaderText + ':', template.productHeaderOffsetX, template.productHeaderOffsetY)
 
@@ -86,10 +92,9 @@ const toCanvas = async (vc, template, canvas) => {
       ctx.fillText(key + ': ' + claimData[i][key], template.claimDataOffsetX, template.claimDataOffsetY + (line * template.claimDataLineSpacing))
     }
   }
-
   let qrImage = await loadImage(vc.qr)
-  ctx.drawImage(qrImage, template.qrOffsetX, template.qrOffsetY, template.qrWidth, template.qrHeight)
-
+  let QRSize = Math.max((42+(8*vc.version))*595/(21*25), template.qrSizeMin)
+  ctx.drawImage(qrImage, template.qrOffsetXright-QRSize, template.qrOffsetYbottom-QRSize, QRSize, QRSize)
   // draw footer
   CanvasTextWrapper(canvas, template.footerText, {
         font: template.footerFont,

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,7 @@ const toCanvas = async (vc, template, canvas) => {
     }
   }
   let qrImage = await loadImage(vc.qr)
+  // Heuristic algorithm to estimate compact QRcode size
   let QRSize = Math.max((42 + (8 * vc.version)) * 595 / (21 * 25), template.qrSizeMin)
   ctx.drawImage(qrImage, template.qrOffsetXright - QRSize, template.qrOffsetYbottom - QRSize, QRSize, QRSize)
   // draw footer

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import jsQR from 'jsqr'
 import * as core from '@discipl/core'
 import stringify from 'json-stable-stringify'
 import { loadImage } from 'canvas'
+var CanvasTextWrapper = require('canvas-text-wrapper').CanvasTextWrapper;
 
 /**
  * a default template
@@ -58,9 +59,20 @@ const toCanvas = async (vc, template, canvas) => {
   let ctx = canvas.getContext('2d')
   ctx.drawImage(await loadImage(template.backgroundImage), 0, 0, canvas.width, canvas.height)
   ctx.drawImage(await loadImage(template.logoImage), 0, 0, template.logoWidth, template.logoHeight)
+  ctx.drawImage(await loadImage(template.disciplImage), template.disciplOffsetX, template.disciplOffsetY, template.disciplWidth, template.disciplHeight)
 
   ctx.font = template.productHeaderFont
   ctx.fillText(template.productHeaderText + ':', template.productHeaderOffsetX, template.productHeaderOffsetY)
+
+  // draw subheader
+  ctx.font = template.subheaderFont
+  ctx.fillText(template.subheaderText, template.subheaderOffsetX, template.subheaderOffsetY)
+
+  // draw a line
+  ctx.beginPath();
+  ctx.moveTo(40, 250);
+  ctx.lineTo(570, 250);
+  ctx.stroke();
 
   ctx.font = template.claimDataFont
   let line = 0
@@ -77,6 +89,14 @@ const toCanvas = async (vc, template, canvas) => {
 
   let qrImage = await loadImage(vc.qr)
   ctx.drawImage(qrImage, template.qrOffsetX, template.qrOffsetY, template.qrWidth, template.qrHeight)
+
+  // draw footer
+  CanvasTextWrapper(canvas, template.footerText, {
+        font: template.footerFont,
+        paddingX: template.footerOffsetX,
+        paddingY: template.footerOffsetY,
+        textAlign: "center"
+      });
 }
 
 /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -61,7 +61,7 @@ describe('descipl-paper-wallet', function () {
       let claimT = await discipl.exportLD(claimLink, attestor)
 
       let vc = await pw.issue(claimLink, attestor)
-      expect (vc.version).to.equal(28)
+      expect(vc.version).to.equal(28)
       let canvas = createCanvas(pw.template.canvasWidth, pw.template.canvasHeight, 'pdf')
       await pw.toCanvas(vc, pw.template, canvas)
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,7 +10,7 @@ let discipl = pw.getCore()
 const fs = require('fs')
 
 describe('descipl-paper-wallet', function () {
-  this.timeout(5000)
+  this.timeout(10000)
   describe('with the discipl paper wallet component', function () {
     it('should be able to issue an attested claim to a document on Canvas, and scan the QR in the document on the canvas and validate it using a given attestor did', async function () {
       let data =
@@ -61,6 +61,7 @@ describe('descipl-paper-wallet', function () {
       let claimT = await discipl.exportLD(claimLink, attestor)
 
       let vc = await pw.issue(claimLink, attestor)
+      expect (vc.version).to.equal(28)
       let canvas = createCanvas(pw.template.canvasWidth, pw.template.canvasHeight, 'pdf')
       await pw.toCanvas(vc, pw.template, canvas)
 
@@ -72,7 +73,6 @@ describe('descipl-paper-wallet', function () {
         creator: 'discipl-paper-wallet',
         creationDate: new Date()
       })
-
       fs.writeFile('/tmp/vc.pdf', buff, function (err) {
         if (err) throw err
         console.log('created /tmp/vc.pdf')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,7 +10,7 @@ let discipl = pw.getCore()
 const fs = require('fs')
 
 describe('descipl-paper-wallet', function () {
-  this.timeout(10000)
+  this.timeout(5000)
   describe('with the discipl paper wallet component', function () {
     it('should be able to issue an attested claim to a document on Canvas, and scan the QR in the document on the canvas and validate it using a given attestor did', async function () {
       let data =


### PR DESCRIPTION
Moved canvas drawings from waardepapiere to paper wallet and mate the QR-image size with QR-level from the bottom-right corner