### PR TITLE
Fixes HDPI issue with CanvasTextWrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/paper-wallet",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "library for creating paper wallets consisting of a QR holding an attested claim as a verifiable credential",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,8 @@ const toCanvas = async (vc, template, canvas) => {
     font: template.footerFont,
     paddingX: template.footerOffsetX,
     paddingY: template.footerOffsetY,
-    textAlign: 'center'
+    textAlign: 'center',
+    renderHDPI: false
   })
 }
 


### PR DESCRIPTION
When HDPI support is turned on, the CanvasTextWrapper tries to rescale
the canvas. Since it's one of the last calls we make, this means that
the rest of the content is erased.

This commit turns off HDPI support in this library, preventing this.